### PR TITLE
yac.mx added (not shure)

### DIFF
--- a/hexxiumthreatlist.txt
+++ b/hexxiumthreatlist.txt
@@ -149,3 +149,4 @@
 ||techstation24x7.com/
 ||goggle.com/
 ||22serversupport.com/
+||yac.mx


### PR DESCRIPTION
This looks like a rouge host. They offered this https://virustotal.com/de/file/e15c8a5d7d6ae943248ba9deb3ec897ced8096be8ea321038c2f731778a4b669/analysis/1470019092/ for download.
