### PR TITLE
findforfun.com added

### DIFF
--- a/hexxiumthreatlist.txt
+++ b/hexxiumthreatlist.txt
@@ -152,3 +152,4 @@
 ||techstation24x7.com/
 ||goggle.com/
 ||22serversupport.com/
+||findforfun.com/


### PR DESCRIPTION
Scam reward site

The root html file seems to be harmless (showing the ip and state code) googling "site:findforfun.com" shows lots of facebook and smartphone app scam sites.
