### PR TITLE
added cnet download site - adware download

### DIFF
--- a/hexxiumthreatlist.txt
+++ b/hexxiumthreatlist.txt
@@ -152,3 +152,5 @@
 ||techstation24x7.com/
 ||goggle.com/
 ||22serversupport.com/
+||download.com
+||download.cnet.com


### PR DESCRIPTION
It is known that cnet offers malware on their download site. <a href="http://www.howtogeek.com/198622/heres-what-happens-when-you-install-the-top-10-download.com-apps/">Here the article</a>.<br>
And I think it didn't change when I visited it.
