### PR TITLE
Update 7/4/18

### DIFF
--- a/hexxiumthreatlist.txt
+++ b/hexxiumthreatlist.txt
@@ -5,9 +5,14 @@
 ! Expires: 2 days
 ! Report domains not being properly blocked to: support@hexxiumcreations.com
 ! (YYYY/MM/DD)
-! Version: 20180627
+! Version: 20180704
 ! USAGE: AVOID SUBDOMAINS, END ALL ENTRIES WITH ^
 !
+||betfarm.top^
+||stelfarm.top^
+||dropnice.top^
+||triumphpccare.com^
+||d2dutzbe4wmvwp.cloudfront.net^
 ||how2find.stream^
 ||movieloving.com^
 ||daffaflix.com^

--- a/hexxiumthreatlist.txt
+++ b/hexxiumthreatlist.txt
@@ -8,6 +8,18 @@
 ! Version: 20180627
 ! USAGE: AVOID SUBDOMAINS, END ALL ENTRIES WITH ^
 !
+||how2find.stream^
+||movieloving.com^
+||daffaflix.com^
+||greatmovies.xyz^
+||cinemaoi.com^
+||siduru.net^
+||moviezu.com^
+||oryweb.com^
+||codesgenerator.science^
+||yrlasvwhatso.download^
+||org-appstore.site^
+||steamconnunuly.com^
 ||giftforsubs.xyz^
 ||bitballon.com^
 ||7ky73hoetj.pw^


### PR DESCRIPTION
Happy forth of July! Here's some more fake movie and phishing sites. Should I continue to add those CS:GO scam sites that Steam bots are going around advertising? They seem to use disposable domains that they abandon after a few days, and it would kinda be wasted effort to add them to the list only for them to switch domains the next day. https://prnt.sc/k2dgrr