### PR TITLE
Update 11/23/2018

### DIFF
--- a/hexxiumthreatlist.txt
+++ b/hexxiumthreatlist.txt
@@ -6,10 +6,24 @@
 ! Expires: 2 days
 ! Report domains not being properly blocked to: support@hexxiumcreations.com
 ! (YYYY/MM/DD)
-! Version: 20181109
+! Version: 20181123
 ! USAGE: AVOID SUBDOMAINS, END ALL ENTRIES WITH ^
 ! We recommend you to use uBlock Origin with this list added to it rather than other adblock products.
 !
+||steamdesktopauthenticator.com^
+||tf2dragon.com^
+||tf2play.com^
+||tradezone.gg^
+||csgofrogman.pro^
+||bitdrop.life^
+||tf2krown.com^
+||tf2next.com^
+||cybertournaments.net^
+||csgoaziimov.com^
+||gamerxskin.com^
+||csgo-aziimov.blogspot.com^
+||item-steam.net^
+||magicxcsgo.com^
 ||anonymoustool.com^
 ||mygiftcard.online^
 ||swiftlet.pro^


### PR DESCRIPTION
Good news - Steam bots that add you to advertise sketchyphishinglink.xyz are becoming less common. Bad news is that they found out it's a lot more efficient to join Steam group chats and use @all without limits. Also added steamdesktopauthenticator.com to the list because they offer a modified version of Steam Desktop Authenticator (an unofficial Steam 2FA emulator) that steals account details once it's used to set up 2FA. An article by BartBlaze cracks open the source code to show where exactly it's being uploaded to. https://bartblaze.blogspot.com/2018/02/fake-steam-desktop-authenticator-steals.html