### PR TITLE
Update 1/17/2019

### DIFF
--- a/hexxiumthreatlist.txt
+++ b/hexxiumthreatlist.txt
@@ -6,10 +6,22 @@
 ! Expires: 2 days
 ! Report domains not being properly blocked to: support@hexxiumcreations.com
 ! (YYYY/MM/DD)
-! Version: 20190114
+! Version: 20190117
 ! USAGE: AVOID SUBDOMAINS, END ALL ENTRIES WITH ^
 ! We recommend you to use uBlock Origin with this list added to it rather than other adblock products.
 !
+||steamity.com^
+||steamcodegenerator.xyz^
+||lakerxdrop.com^
+||luxurycases.life^
+||drop-xbest.com^
+||buyofficialkey.com^
+||key4sales.com^
+||gastonfiore.com^
+||microsoftkeyoffsale.com^
+||keysforvip.com^
+||mskeysale.com^
+||keysdealstore.com^
 ||favorite-dropx.pro^
 ||tf2goost.com^
 ||drop-xgood.com^


### PR DESCRIPTION
But... I get a 10% discount if I send them my card details in plain text! /s

Some of the sites I shared in the previous list were no longer online, but I remember them having a very similar layout to buyofficialkey.com so I'm going to treat them the same.

Excluding vankeys.com, aakeys.com, and buymsproductkey.com due to the fact that they accept PayPal as a payment method and I couldn't find any complaints against them.
buymsproductkey.com also accepts PayPal, and since literally everything on their site is out of stock it suggests they aren't out to scam people.

And a few Steam scams, as usual